### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -12,9 +12,9 @@ Blinker	KEYWORD1
 # Methods and Functions (KEYWORD2)
 #######################################
 
-on		    KEYWORD2
-off		    KEYWORD2
-once        KEYWORD2
+on	KEYWORD2
+off	KEYWORD2
+once	KEYWORD2
 continuous	KEYWORD2
 
 


### PR DESCRIPTION
The Arduino IDE currently requires the use of a tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords